### PR TITLE
 emergency Fix Monkey Patches

### DIFF
--- a/addon/globalPlugins/subtitle_reader/potPlayer.py
+++ b/addon/globalPlugins/subtitle_reader/potPlayer.py
@@ -22,8 +22,8 @@ class PotPlayer:
 		speech.speech.processText = self.oldProcessText
 		winInputHook.keyDownCallback = self.oldKeyDown
 	
-	def processText(self, locale, text, symbolLevel):
-		text = self.oldProcessText(locale, text, symbolLevel)
+	def processText(self, locale, text, symbolLevel, *args, **kwargs):
+		text = self.oldProcessText(locale, text, symbolLevel, *args, **kwargs)
 		if not conf['switch']:
 			return text
 		


### PR DESCRIPTION
The latest alpha version of NVDA adds a parameter to the `speech.speech.processText` method that the `PotPlayer.processText` patch is unable to parse, preventing speech from being played.